### PR TITLE
allow dateparts without day specified

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,16 +85,20 @@ export function DateZFromDateParts(d: DateParts, opts: DateParseOpts = DefaultOp
     throw new Error('Malformed DateParts: Multiple DateParts possibilities found')
   }
 
+  // choose the first dateparts in the list.
+  // TODO this is opinionated behavior and may need to adapt.
   const best = p[0]
-  if (best.length != 3) {
-    throw new Error('Malformed DateParts: Must have exactly year, month, and day')
+
+  switch (best.length) {
+      case 1:
+        return new Date(Date.UTC(best[0], 0, 1))
+      case 2:
+        return new Date(Date.UTC(best[0], best[1] - 1, 1))
+      case 3:
+        return new Date(Date.UTC(best[0], best[1] - 1, best[2]))
+      default:
+    throw new Error('Malformed DateParts: Must have 1, 2, or 3 parts')
   }
-
-  const yr = best[0]
-  const moIdx = best[1] - 1
-  const day = best[2]
-
-  return new Date(Date.UTC(yr, moIdx, day))
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,14 +90,14 @@ export function DateZFromDateParts(d: DateParts, opts: DateParseOpts = DefaultOp
   const best = p[0]
 
   switch (best.length) {
-      case 1:
-        return new Date(Date.UTC(best[0], 0, 1))
-      case 2:
-        return new Date(Date.UTC(best[0], best[1] - 1, 1))
-      case 3:
-        return new Date(Date.UTC(best[0], best[1] - 1, best[2]))
-      default:
-    throw new Error('Malformed DateParts: Must have 1, 2, or 3 parts')
+    case 1:
+      return new Date(Date.UTC(best[0], 0, 1))
+    case 2:
+      return new Date(Date.UTC(best[0], best[1] - 1, 1))
+    case 3:
+      return new Date(Date.UTC(best[0], best[1] - 1, best[2]))
+    default:
+      throw new Error('Malformed DateParts: Must have 1, 2, or 3 parts')
   }
 }
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -20,7 +20,9 @@ test('date utilities: DateParts only', async (t) => {
 })
 
 test('date utilities: DateParts only with only year and month', async (t) => {
-  const result = U.DatemorphISOString({ 'date-parts': [CONSISTENT_DATE['date-parts'][0].slice(0,1)] })
+  const result = U.DatemorphISOString({
+    'date-parts': [CONSISTENT_DATE['date-parts'][0].slice(0, 1)],
+  })
   t.is(result, '2021-01-01T00:00:00.000Z')
 })
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -19,6 +19,11 @@ test('date utilities: DateParts only', async (t) => {
   t.is(result, '2021-01-21T00:00:00.000Z')
 })
 
+test('date utilities: DateParts only with only year and month', async (t) => {
+  const result = U.DatemorphISOString({ 'date-parts': [CONSISTENT_DATE['date-parts'][0].slice(0,1)] })
+  t.is(result, '2021-01-01T00:00:00.000Z')
+})
+
 test('date utilities: Inconsistent date, strict', async (t) => {
   t.throws(() => {
     U.DatemorphISOString(INCONSISTENT_DATE)


### PR DESCRIPTION
This is required to handle examples like [this one](https://api.crossref.org/works/10.1016/j.jaac.2016.07.660): there are DateParts that only have year and month, but are valid.